### PR TITLE
Fix Chatbot Conversations list never finishes loading

### DIFF
--- a/Ui/DataProvider/ConversationDataProvider.php
+++ b/Ui/DataProvider/ConversationDataProvider.php
@@ -66,21 +66,24 @@ class ConversationDataProvider extends DataProvider
      */
     public function getData()
     {
-        if (isset($this->loadedData)) {
-            return $this->loadedData;
-        }
-        $items = $this->getCollection()->getItems();
-        $this->loadedData = [];
-        foreach ($items as $conversation) {
+        $collection = $this->getCollection();
+
+        $items = [];
+        foreach ($collection->getItems() as $conversation) {
             // Add the count of messages
             $messages = json_decode($conversation->getConversationData(), true);
             $messageCount = !empty($messages['messages']) ? count($messages['messages']) : 0;
             $conversation->setData('message_count', $messageCount);
-            
-            $this->loadedData[$conversation->getId()] = $conversation->getData();
+
+            $items[] = $conversation->getData();
         }
-        
-        return $this->loadedData;
+
+        $result = [
+            'items' => $items,
+            'totalRecords' => $collection->getSize()
+        ];
+
+        return $result;
     }
 
     /**
@@ -92,7 +95,7 @@ class ConversationDataProvider extends DataProvider
     {
         return $this->createCollection();
     }
-    
+
     /**
      * Create collection instance
      *
@@ -106,4 +109,17 @@ class ConversationDataProvider extends DataProvider
         }
         return $collection;
     }
+
+    /**
+     * Add filter
+     *
+     * @param Filter $filter
+     * @return void
+     */
+    public function addFilter(Filter $filter)
+    {
+        // Handle custom filters here if needed
+        parent::addFilter($filter);
+    }
+
 }

--- a/view/adminhtml/ui_component/chatbot_conversation_listing.xml
+++ b/view/adminhtml/ui_component/chatbot_conversation_listing.xml
@@ -36,6 +36,7 @@
             </item>
         </argument>
     </dataSource>
+
     <listingToolbar name="listing_top">
         <argument name="data" xsi:type="array">
             <item name="config" xsi:type="array">
@@ -170,6 +171,33 @@
                     <item name="resizeEnabled" xsi:type="boolean">false</item>
                     <item name="resizeDefaultWidth" xsi:type="string">107</item>
                     <item name="indexField" xsi:type="string">conversation_id</item>
+                </item>
+                <item name="action_list" xsi:type="array">
+                    <item name="view" xsi:type="array">
+                        <item name="label" xsi:type="string" translate="true">View</item>
+                        <item name="path" xsi:type="string">magentomcpai/conversation/view</item>
+                        <item name="params" xsi:type="array">
+                            <item name="id" xsi:type="string">conversation_id</item>
+                        </item>
+                    </item>
+                    <item name="send_transcript" xsi:type="array">
+                        <item name="label" xsi:type="string" translate="true">Send Transcript</item>
+                        <item name="path" xsi:type="string">magentomcpai/conversation/send</item>
+                        <item name="params" xsi:type="array">
+                            <item name="id" xsi:type="string">conversation_id</item>
+                        </item>
+                    </item>
+                    <item name="delete" xsi:type="array">
+                        <item name="label" xsi:type="string" translate="true">Delete</item>
+                        <item name="path" xsi:type="string">magentomcpai/conversation/delete</item>
+                        <item name="params" xsi:type="array">
+                            <item name="id" xsi:type="string">conversation_id</item>
+                        </item>
+                        <item name="confirm" xsi:type="array">
+                            <item name="title" xsi:type="string" translate="true">Delete Conversation</item>
+                            <item name="message" xsi:type="string" translate="true">Are you sure you want to delete this conversation?</item>
+                        </item>
+                    </item>
                 </item>
             </argument>
         </actionsColumn>


### PR DESCRIPTION
When you go to Marketing > Chatbot Conversations it never finishes loading the records from the "chatbot_conversations" table.

I also defined the column actions differently in the UI component. This has nothing to do with the bug, but in my opinion, it's more readable.