### PR TITLE
Cacheable tag is not allowed on container element

### DIFF
--- a/view/adminhtml/layout/magentomcpai_chat_iframe.xml
+++ b/view/adminhtml/layout/magentomcpai_chat_iframe.xml
@@ -21,10 +21,11 @@
         <referenceContainer name="footer" remove="true"/>
 
         <!-- Define our own basic content container -->
-        <container name="root" htmlTag="div" cacheable="false" htmlClass="mcpai-iframe-root">
+        <container name="root" htmlTag="div" htmlClass="mcpai-iframe-root">
             <block name="magentomcpai_iframe" 
-                   template="Genaker_MagentoMcpAi::iframe.phtml" 
-                   class="Genaker\MagentoMcpAi\Block\Adminhtml\Chat"/>
+                cacheable="false"
+                template="Genaker_MagentoMcpAi::iframe.phtml"
+                class="Genaker\MagentoMcpAi\Block\Adminhtml\Chat"/>
         </container>
     </body>
 </page> 


### PR DESCRIPTION
Adobe commerce: 2.4.8-p2

<img width="1542" height="559" alt="image" src="https://github.com/user-attachments/assets/78acdbd9-5c5f-43b9-bc41-d9398cbb4b83" />
